### PR TITLE
Fix upgrade script again

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -198,7 +198,7 @@ verify_server_ssl_certificates="true"
 matrix_server_supports_asmux="false"
 log_filename="/var/log/$app/$app.log"
 # https://docs.python.org/3.6/library/logging.html#logging-levels
-log_level="DEBUG"
+log_level="INFO"
 
 ynh_add_config --template="../conf/config.yaml" --destination="$mautrix_config_path"
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -202,6 +202,9 @@ $final_path/bin/python3 -m mautrix_signal -g -c $mautrix_config_path -r $app_ser
 chown -R root: $final_path
 chown $mautrix_bridge_user:root -R $final_path
 
+# Fix possible permission issues with a previous signald version, esp. with stickers
+chmod -R g+rwX /var/lib/signald/{avatars,attachments,stickers}
+
 #=================================================
 # SETUP LOGROTATE
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -163,8 +163,8 @@ ynh_backup_if_checksum_is_different --file="$mautrix_config_path"
 
 verify_server_ssl_certificates="true"
 matrix_server_supports_asmux="false"
-    # Options: debug, info, warn, error, fatal
-log_level="error"
+# https://docs.python.org/3.6/library/logging.html#logging-levels
+log_level="INFO"
 
 ynh_add_config --template="../conf/config.yaml" --destination="$mautrix_config_path"
 


### PR DESCRIPTION
## Problem
- Current upgrade script doesn't work as the log level is invalid
- users who have been running signald for a bit might have wrong permissions on their sticker folders. That fixes it.

## Solution
- Replace `error` with `ERROR`.
- Actually, make it the same as in the install script. `DEBUG` might be a bit verbose, we can ask users they change this when debugging. So I put everything at `INFO`.
- Chmod the stickers subfolder recursively.

## PR Status
- [X] Code finished.
- [ ] Tested with Package_check.
- [X] Fix or enhancement tested.
- [X] Upgrade from last version tested.
- [X] Can be reviewed and tested.

## Package_check results
---
*If you have access to [App Continuous Integration for packagers](https://yunohost.org/#/packaging_apps_ci) you can provide a link to the package_check results like below, replacing '-NUM-' in this link by the PR number and USERNAME by your username on the ci-apps-dev. Or you provide a screenshot or a pastebin of the results*

[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/mautrix_signal_ynh%20PR-NUM-%20(USERNAME)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/mautrix_signal_ynh%20PR-NUM-%20(USERNAME)/)  
