### PR TITLE
Use debs for updating instead of relying on ynh helper

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -7,9 +7,61 @@
 # dependencies used by the app
 pkg_dependencies="postgresql python3"
 extra_dependencies="libunixsocket-java signald>=0.15.0-27 signaldctl"
+
 #=================================================
 # PERSONAL HELPERS
 #=================================================
+
+# Usage:
+# $1 URL
+# $2 hash
+# $3 user-friendly name
+function install_deb {
+	local URL="$1"
+	local sha256sum="$2"
+	local name="$3"
+
+	local temp_folder="$(mktemp -d)"
+	local deb_dst="$temp_folder/target_deb.deb"
+	ynh_exec_quiet "wget -q -O \"$deb_dst\" \"$URL\""
+	echo "$sha256sum  $deb_dst" | sha256sum -c
+	DEBIAN_FRONTEND=noninteractive ynh_exec_warn_less apt-get install -yq -o Dpkg::Options::='--force-confold' "$deb_dst"
+	ynh_secure_remove "$temp_folder"
+}
+
+function install_signald {
+	local arch=$(dpkg --print-architecture)
+	local version=0.15.0-27-88722d97
+	# arch suffixes
+	local URL=https://updates.signald.org/pool/main/s/signald/signald_${version}_${arch}.deb
+	local -A sha256_signald # hash dictionary
+	sha256_signald['amd64']=4cc1c3410c224307f24a2c224a55725efa4f620ff54e01933d7b0ce61332c87e
+	sha256_signald['arm64']=797dd6764ac535345c5d58884bfa222c367b97a3b74f776896b1ef36ef39164b
+	sha256_signald['armhf']=d2fd2ebbdd7fe1ca35b8491239d8665699e9e5db1ec007551cc64084c3bfca95
+	install_deb "$URL" ${sha256_signald[$arch]} signald
+}
+
+function install_signaldctl {
+	local arch=$(dpkg --print-architecture)
+	local version=0.3.0-11-dd56e3d6
+	# arch suffixes
+	local URL=https://updates.signald.org/pool/main/s/signaldctl/signaldctl_${version}_${arch}.deb
+	local -A sha256_signald # hash dictionary
+	sha256_signald['amd64']=a4dbf79441b28026645fd61e926a7c63231f2c7a2cd81c44658b7b51ecae6eee
+	sha256_signald['arm64']=15fb4f187a0756137c210fad4898bdc35fd862aeb230291a8fc7100b1fe66058
+	sha256_signald['armhf']=69c2ed93fe4e3787b081ea51c889dcdbfe1baff467f93b0573bf46f0095ed889
+	install_deb "$URL" ${sha256_signald[$arch]} signaldctl
+}
+
+
+function install_mautrix_signal_deps {
+	install_signaldctl
+	install_signald
+}
+
+function remove_mautrix_signal_deps {
+	ynh_exec_warn_less dpkg -r signald signaldctl
+}
 
 #=================================================
 # EXPERIMENTAL HELPERS

--- a/scripts/install
+++ b/scripts/install
@@ -119,7 +119,7 @@ ynh_script_progression --message="Installing dependencies..." --weight=97
 
 ynh_install_app_dependencies $pkg_dependencies
 
-ynh_install_extra_app_dependencies --repo="https://updates.signald.org unstable main" --package="$extra_dependencies" --key="https://updates.signald.org/apt-signing-key.asc"
+install_mautrix_signal_deps # custom helper from _common.sh
 
 #=================================================
 # CREATE A POSTGRESQL DATABASE

--- a/scripts/remove
+++ b/scripts/remove
@@ -94,6 +94,8 @@ ynh_script_progression --message="Removing dependencies..." --weight=8
 # Remove metapackage and its dependencies
 ynh_remove_app_dependencies
 
+remove_mautrix_signal_deps # from _common.sh
+
 #=================================================
 # REMOVE APP MAIN DIR
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -125,7 +125,7 @@ ynh_script_progression --message="Upgrading dependencies..." --time --weight=1
 
 ynh_install_app_dependencies $pkg_dependencies
 
-ynh_install_extra_app_dependencies --repo="https://updates.signald.org unstable main" --package="$extra_dependencies" --key="https://updates.signald.org/apt-signing-key.asc"
+install_mautrix_signal_deps # from _common.sh
 
 #=================================================
 # CREATE DEDICATED USER


### PR DESCRIPTION
## Problem
- closes #22 Yunohost helper doesn't actually upgrade extra dependencies (probably needs an upstream bug report)

## Solution
- Install debs from the repo and check their sha256sums instead of relying on yunohost's helper or apt.

## PR Status
- [X] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [X] Can be reviewed and tested.

## Package_check results
---
*If you have access to [App Continuous Integration for packagers](https://yunohost.org/#/packaging_apps_ci) you can provide a link to the package_check results like below, replacing '-NUM-' in this link by the PR number and USERNAME by your username on the ci-apps-dev. Or you provide a screenshot or a pastebin of the results*

[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/mautrix_signal_ynh%20PR-NUM-%20(USERNAME)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/mautrix_signal_ynh%20PR-NUM-%20(USERNAME)/)  
