### PR TITLE
(Buster version) Fix appending the logrotate config twice during upgrade

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -199,7 +199,7 @@ ynh_store_file_checksum --file="/etc/matrix-$synapse_instance/app-service/$app.y
 ynh_script_progression --message="Upgrading logrotate configuration..." --weight=1
 
 # Use logrotate to manage application logfile(s)
-ynh_use_logrotate
+ynh_use_logrotate --non-append
 chmod -R 600 "/var/log/$app"
 chmod 700 "/var/log/$app"
 chown -R $app:$app /var/log/$app


### PR DESCRIPTION
Related to #49 on the buster branch. Merge after CI passes in #51.

## PR Status
- [X] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [X] Can be reviewed and tested.

## Package_check results
---
*If you have access to [App Continuous Integration for packagers](https://yunohost.org/#/packaging_apps_ci) you can provide a link to the package_check results like below, replacing '-NUM-' in this link by the PR number and USERNAME by your username on the ci-apps-dev. Or you provide a screenshot or a pastebin of the results*

[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/mautrix_signal_ynh%20PR-NUM-%20(USERNAME)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/mautrix_signal_ynh%20PR-NUM-%20(USERNAME)/)  
