### PR TITLE
add support for armhf

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -7,6 +7,13 @@
 # dependencies used by the app
 pkg_dependencies="postgresql python3 python3-dev build-essential"
 extra_dependencies="libunixsocket-java signald signaldctl"
+
+# rustc is mandatory as weel is not existent for arm32 bits
+if [ $YNH_ARCH == "armhf" ] 
+then
+	pkg_dependencies_arm="rustc"
+	pkg_dependencies="$pkg_dependencies $pkg_dependencies_arm"
+fi
 #=================================================
 # PERSONAL HELPERS
 #=================================================


### PR DESCRIPTION
need rustc to compile weel 32b

## Problem
- can not be installed because rustc inexistent

## Solution
- manualy apt install rustc
- or add in dependencies for $YNH_ARCH="armhf"

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.
before rustc install : https://paste.yunohost.org/raw/dotohujaba
after (install well) :https://paste.yunohost.org/raw/nubajevife