### PR TITLE
Restore: Fix permission for config.yaml

### DIFF
--- a/scripts/restore
+++ b/scripts/restore
@@ -48,7 +48,7 @@ ynh_script_progression --message="Registering Synapse app-service" --weight=1
 $install_dir/mautrix-signal -g -c $install_dir/config.yaml -r /etc/matrix-$synapse_instance/app-service/$app.yaml
 /opt/yunohost/matrix-$synapse_instance/update_synapse_for_appservice.sh || ynh_die --message="Synapse can't restart with the appservice configuration"
 
-chown -R $app:$app "$install_dir"
+chown -R $app:$app "$install_dir/config.yaml"
 ynh_store_file_checksum --file="/etc/matrix-$synapse_instance/app-service/$app.yaml"
 ynh_store_file_checksum --file="$install_dir/config.yaml"
 


### PR DESCRIPTION
## Problem

> However, afterwards the service stopped again with another error PermissionError: [Errno 13] Permission denied: 'config.yaml'. I could solve this by running chown mautrix_signal:mautrix_signal config.yaml  from /opt/yunohost/mautrix_signal. Previously the folder was owned by root:root.

Problem from https://github.com/YunoHost-Apps/mautrix_signal_ynh/issues/101

## Solution

Just like in the restore script of the Mautrix Whatsapp bridge, I added a `chown` command for `config.yaml`. See `chown` command in Mautrix Whatsapp bridge restore script: https://github.com/YunoHost-Apps/mautrix_whatsapp_ynh/blob/master/scripts/restore#L47

Previously there was a `chown` command for the whole `$install_dir`. However, this `chown` command is already defined in https://github.com/YunoHost-Apps/mautrix_signal_ynh/blob/master/scripts/restore#L25 making it redundant.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
