### PR TITLE
Fix synapse DB name in upgrade

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -10,7 +10,7 @@ source _common.sh
 source /usr/share/yunohost/helpers
 
 mautrix_version=$(ynh_app_upstream_version)
-synapse_db_name="matrix_$synapse_instance"
+synapse_db_name="$(get_synapse_db_name $synapse_instance)"
 server_name=$(ynh_app_setting_get --app $synapse_instance --key server_name)
 domain=$(ynh_app_setting_get --app $synapse_instance --key domain)
 


### PR DESCRIPTION
## Problem

Synapse DB name was hardcoded with old DB name `matrix_$app` although in Synapse package it was renamed to `$app`. See https://github.com/YunoHost-Apps/synapse_ynh/blob/master/scripts/upgrade#L194

## Solution

Use function `get_synapse_db_name` to retrieve the actual DB name dynamically.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
