### PR TITLE
`!signal` instead of `!sg` and remove `admin and `domain` option in manifest

### DIFF
--- a/ALL_README.md
+++ b/ALL_README.md
@@ -5,4 +5,5 @@
 - [Irakurri README euskaraz](README_eu.md)
 - [Lire le README en français](README_fr.md)
 - [Le o README en galego](README_gl.md)
+- [Baca README dalam bahasa bahasa Indonesia](README_id.md)
 - [阅读中文（简体）的 README](README_zh_Hans.md)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Currently the Matrix user can NOT invite other Matrix user in a bridged Signal r
 The ["Mautrix-Signal"](https://docs.mau.fi/bridges/go/signal/index.html) bridge consists in a Synapse App Service and relies on postgresql (mysql also possible). Therefore, [Synapse for YunoHost](https://github.com/YunoHost-Apps/synapse_ynh) should be installed beforehand.
 
 
-**Shipped version:** 0.6.2~ynh1
+**Shipped version:** 0.6.3~ynh2
 ## Documentation and resources
 
 - Official user documentation: <https://docs.mau.fi/bridges/go/signal/index.html>

--- a/README_es.md
+++ b/README_es.md
@@ -22,7 +22,7 @@ Currently the Matrix user can NOT invite other Matrix user in a bridged Signal r
 The ["Mautrix-Signal"](https://docs.mau.fi/bridges/go/signal/index.html) bridge consists in a Synapse App Service and relies on postgresql (mysql also possible). Therefore, [Synapse for YunoHost](https://github.com/YunoHost-Apps/synapse_ynh) should be installed beforehand.
 
 
-**Versión actual:** 0.6.2~ynh1
+**Versión actual:** 0.6.3~ynh2
 ## Documentaciones y recursos
 
 - Documentación usuario oficial: <https://docs.mau.fi/bridges/go/signal/index.html>

--- a/README_eu.md
+++ b/README_eu.md
@@ -22,7 +22,7 @@ Currently the Matrix user can NOT invite other Matrix user in a bridged Signal r
 The ["Mautrix-Signal"](https://docs.mau.fi/bridges/go/signal/index.html) bridge consists in a Synapse App Service and relies on postgresql (mysql also possible). Therefore, [Synapse for YunoHost](https://github.com/YunoHost-Apps/synapse_ynh) should be installed beforehand.
 
 
-**Paketatutako bertsioa:** 0.6.2~ynh1
+**Paketatutako bertsioa:** 0.6.3~ynh2
 ## Dokumentazioa eta baliabideak
 
 - Erabiltzaileen dokumentazio ofiziala: <https://docs.mau.fi/bridges/go/signal/index.html>

--- a/README_fr.md
+++ b/README_fr.md
@@ -23,7 +23,7 @@ La passerelle ["Mautrix-Signal"](https://docs.mau.fi/bridges/python/signal/index
 **Attention : sauvegardez et restaurez toujours les deux applications Yunohost matrix-synapse et mautrix_signal en même temps!**
 
 
-**Version incluse :** 0.6.2~ynh1
+**Version incluse :** 0.6.3~ynh2
 ## Documentations et ressources
 
 - Documentation officielle utilisateur : <https://docs.mau.fi/bridges/go/signal/index.html>

--- a/README_gl.md
+++ b/README_gl.md
@@ -22,7 +22,7 @@ Currently the Matrix user can NOT invite other Matrix user in a bridged Signal r
 The ["Mautrix-Signal"](https://docs.mau.fi/bridges/go/signal/index.html) bridge consists in a Synapse App Service and relies on postgresql (mysql also possible). Therefore, [Synapse for YunoHost](https://github.com/YunoHost-Apps/synapse_ynh) should be installed beforehand.
 
 
-**Versión proporcionada:** 0.6.2~ynh1
+**Versión proporcionada:** 0.6.3~ynh2
 ## Documentación e recursos
 
 - Documentación oficial para usuarias: <https://docs.mau.fi/bridges/go/signal/index.html>

--- a/README_id.md
+++ b/README_id.md
@@ -1,0 +1,45 @@
+<!--
+N.B.: README ini dibuat secara otomatis oleh <https://github.com/YunoHost/apps/tree/master/tools/readme_generator>
+Ini TIDAK boleh diedit dengan tangan.
+-->
+
+# Matrix Signal bridge untuk YunoHost
+
+[![Tingkat integrasi](https://dash.yunohost.org/integration/mautrix_signal.svg)](https://ci-apps.yunohost.org/ci/apps/mautrix_signal/) ![Status kerja](https://ci-apps.yunohost.org/ci/badges/mautrix_signal.status.svg) ![Status pemeliharaan](https://ci-apps.yunohost.org/ci/badges/mautrix_signal.maintain.svg)
+
+[![Pasang Matrix Signal bridge dengan YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=mautrix_signal)
+
+*[Baca README ini dengan bahasa yang lain.](./ALL_README.md)*
+
+> *Paket ini memperbolehkan Anda untuk memasang Matrix Signal bridge secara cepat dan mudah pada server YunoHost.*  
+> *Bila Anda tidak mempunyai YunoHost, silakan berkonsultasi dengan [panduan](https://yunohost.org/install) untuk mempelajari bagaimana untuk memasangnya.*
+
+## Ringkasan
+
+A puppeting bridge between Matrix and Signal packaged as a YunoHost service. Messages, notifications (and sometimes media) are bridged between a Signal user and a Matrix user.
+Currently the Matrix user can NOT invite other Matrix user in a bridged Signal room, so only someone with a Signal account can participate to Signal group conversations.
+
+The ["Mautrix-Signal"](https://docs.mau.fi/bridges/go/signal/index.html) bridge consists in a Synapse App Service and relies on postgresql (mysql also possible). Therefore, [Synapse for YunoHost](https://github.com/YunoHost-Apps/synapse_ynh) should be installed beforehand.
+
+
+**Versi terkirim:** 0.6.3~ynh2
+## Dokumentasi dan sumber daya
+
+- Dokumentasi pengguna resmi: <https://docs.mau.fi/bridges/go/signal/index.html>
+- Repositori kode aplikasi hulu: <https://github.com/mautrix/signal>
+- Gudang YunoHost: <https://apps.yunohost.org/app/mautrix_signal>
+- Laporkan bug: <https://github.com/YunoHost-Apps/mautrix_signal_ynh/issues>
+
+## Info developer
+
+Silakan kirim pull request ke [`testing` branch](https://github.com/YunoHost-Apps/mautrix_signal_ynh/tree/testing).
+
+Untuk mencoba branch `testing`, silakan dilanjutkan seperti:
+
+```bash
+sudo yunohost app install https://github.com/YunoHost-Apps/mautrix_signal_ynh/tree/testing --debug
+atau
+sudo yunohost app upgrade mautrix_signal -u https://github.com/YunoHost-Apps/mautrix_signal_ynh/tree/testing --debug
+```
+
+**Info lebih lanjut mengenai pemaketan aplikasi:** <https://yunohost.org/packaging_apps>

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -22,7 +22,7 @@ Currently the Matrix user can NOT invite other Matrix user in a bridged Signal r
 The ["Mautrix-Signal"](https://docs.mau.fi/bridges/go/signal/index.html) bridge consists in a Synapse App Service and relies on postgresql (mysql also possible). Therefore, [Synapse for YunoHost](https://github.com/YunoHost-Apps/synapse_ynh) should be installed beforehand.
 
 
-**分发版本：** 0.6.2~ynh1
+**分发版本：** 0.6.3~ynh2
 ## 文档与资源
 
 - 官方用户文档： <https://docs.mau.fi/bridges/go/signal/index.html>

--- a/doc/ADMIN.md
+++ b/doc/ADMIN.md
@@ -11,12 +11,12 @@
 * First your Matrix user or Synapse Server has to be authorized in the Configuration of the bridge (see below)
 * Then, invite the bot (default @signalbot:yoursynapse.domain) in this new Mautrix-Signal bot administration room.
   * If the Bot does bot accept, see the [troubleshooting page](https://docs.mau.fi/bridges/general/troubleshooting.html)
-* Send ``!sg help`` to the bot in the created room to know how to control the bot.
+* Send ``!signal help`` to the bot in the created room to know how to control the bot.
 See also [upstream wiki Authentication page](https://docs.mau.fi/bridges/go/signal/authentication.html)
 
 #### Linking the Bridge as a secondary device
 
-* Type ``!sg link``
+* Type ``!signal link``
 * Open Signal App of your primary device
 * Open Settings => Linked Devices => + => Capture the QR code with the camera
 * By defaults, only conversations with very recent messages will be bridged
@@ -24,9 +24,9 @@ See also [upstream wiki Authentication page](https://docs.mau.fi/bridges/go/sign
 
 #### Registering the Bridge as a primary device
 
-* Type ``!sg register <phone>``, where ``<phone>`` is your phone number in the international format with no space, e.g. ``!sg register +33612345678``
+* Type ``!signal register <phone>``, where ``<phone>`` is your phone number in the international format with no space, e.g. ``!signal register +33612345678``
 * Answer in the bot room with the verification code that you reveived in SMS.
-* Set a profile name with ``!sg set-profile-name <name>``
+* Set a profile name with ``!signal set-profile-name <name>``
 
 ### Double puppeting
 
@@ -38,7 +38,7 @@ See also [upstream wiki Authentication page](https://docs.mau.fi/bridges/go/sign
 * Create a room on the signal side
 * Your bridged users will be invited on the Matrix side once they are invited on the Signal side
 * You can invite more people over on the Matrix side
-* Have one of the bridged users (who has the right permission) type `!sg set-relay` on the Matrix side. Their signal account will relay messages from other Matrix users
+* Have one of the bridged users (who has the right permission) type `!signal set-relay` on the Matrix side. Their signal account will relay messages from other Matrix users
 It is not yet possible to bridge to an existing signal room, or create a new signal room from the Matrix side.
 
 ## Configuration of the bridge

--- a/doc/ADMIN_fr.md
+++ b/doc/ADMIN_fr.md
@@ -16,7 +16,7 @@ Voir aussi [upstream wiki Authentication page](https://docs.mau.fi/bridges/pytho
 
 #### Relier la passerelle comme un appareil secondaire
 
-* Tapez ``!sg link``
+* Tapez ``!signal link``
 * Ouvrez l'application Signal de votre appareil principal
 * Ouvrez Paramètres => Appareils reliés => + => filmer le QR
 * Par défaut, seules les conversations avec des messages très récents seront mises-en-miroir
@@ -24,9 +24,9 @@ Voir aussi [upstream wiki Authentication page](https://docs.mau.fi/bridges/pytho
 
 #### Enregistrer la passerelle comme appareil principal
 
-* Tapez ``!sg register <phone>``, où ``<phone>`` est votre numéro de téléphone au format international sans espace, p.ex. ``!sg register +33612345678``
+* Tapez ``!signal register <phone>``, où ``<phone>`` est votre numéro de téléphone au format international sans espace, p.ex. ``!signal register +33612345678``
 * Répondez dans le salon d'administration avec le code de vérification reçu par SMS.
-* Définissez une nom de profil ``!sg set-profile-name <name>``
+* Définissez une nom de profil ``!signal set-profile-name <name>``
 
 ### Robot-Relai "Relaybot": Relayer les conversations de TOUS les comptes Matrix et TOUS les comptes Signal présents dans UN groupe/salon
 

--- a/doc/PRE_UPGRADE.d/0.6.3~ynh2.md
+++ b/doc/PRE_UPGRADE.d/0.6.3~ynh2.md
@@ -1,0 +1,1 @@
+With this upgrade, the command `!sg` will be replaced by `!signal`. 

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Matrix Signal bridge"
 description.en = "Matrix / Synapse puppeting bridge for Signal"
 description.fr = "Passerelle Matrix / Synapse pour Signal"
 
-version = "0.6.2~ynh1"
+version = "0.6.3~ynh2"
 
 maintainers = ["MayeulC", "nathanael-h"]
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -74,11 +74,10 @@ ram.runtime = "128M"
     [install.botusers]
     ask.en = "Choose Matrix user(s) authorized to bridge with the Signal bot"
     ask.fr = "Choisissez le/les compte(s) Matrix autorisés à utiliser la passerelle Signal"
-    help.en = "Either the administrator only (admin), all local Synapse users (domain), a remote or local user (@johndoe:server.name), a remote server (matrix.org), or all remote/local servers (*) can be authorized. Give the Matrix server_name, not the full domain/URL."
-    help.fr = "L'administrateur seulement (admin), tous les comptes Synapse locaux (domain), un compte local ou distant (@johndoe:server.name), un serveur distant (matrix.org), ou tous les serveurs remote/local (*). Donner le nom du serveur Matrix, pas le domaine/URL complet."
     type = "string"
-    example = "admin or domain or @johndoe:server.name or server.name or *"
-    default = "domain"
+    example = "@johndoe:server.name or server.name or *"
+    help.en = "A remote or local user (@johndoe:server.name),the local server (server.name), a remote server (matrix.org), or all remote/local servers (*) can be authorized. Give the Matrix server_name, not the full domain/URL. It is also possible to specify multiple values by separating them with comma. Example: @johndoe:server.name,domain.tld,matrix.org"
+    help.fr = "Un compte local ou distant (@johndoe:server.name), le serveur local (server.name), un serveur distant (matrix.org), ou tous les serveurs remote/local (*). Donner le nom du serveur Matrix, pas le domaine/URL complet. Il est également possible de spécifier plusieurs valeurs en les séparant par une virgule. Exemple : @johndoe:server.name,domain.tld,matrix.org"
 
     [install.enable_relaybot]
     ask.en = "Choose whether to enable the relay bot feature"


### PR DESCRIPTION
## Problem

`!sg` has been replaced by `!signal` and  `admin and `domain` don't seem to be viable option settings to mention in manifest.toml (I got inspiration for the rewrite from the mautrix_whatsapp app)

## Solution

- *And how do you fix that problem*

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
