### PR TITLE
Cleanup leftover Python files and unused bot admin feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Currently the Matrix user can NOT invite other Matrix user in a bridged Signal r
 The ["Mautrix-Signal"](https://docs.mau.fi/bridges/go/signal/index.html) bridge consists in a Synapse App Service and relies on postgresql (mysql also possible). Therefore, [Synapse for YunoHost](https://github.com/YunoHost-Apps/synapse_ynh) should be installed beforehand.
 
 
-**Shipped version:** 0.7.4~ynh1
+**Shipped version:** 0.7.4~ynh2
 ## Documentation and resources
 
 - Official user documentation: <https://docs.mau.fi/bridges/go/signal/index.html>

--- a/README_es.md
+++ b/README_es.md
@@ -24,7 +24,7 @@ Currently the Matrix user can NOT invite other Matrix user in a bridged Signal r
 The ["Mautrix-Signal"](https://docs.mau.fi/bridges/go/signal/index.html) bridge consists in a Synapse App Service and relies on postgresql (mysql also possible). Therefore, [Synapse for YunoHost](https://github.com/YunoHost-Apps/synapse_ynh) should be installed beforehand.
 
 
-**Versión actual:** 0.7.4~ynh1
+**Versión actual:** 0.7.4~ynh2
 ## Documentaciones y recursos
 
 - Documentación usuario oficial: <https://docs.mau.fi/bridges/go/signal/index.html>

--- a/README_eu.md
+++ b/README_eu.md
@@ -24,7 +24,7 @@ Currently the Matrix user can NOT invite other Matrix user in a bridged Signal r
 The ["Mautrix-Signal"](https://docs.mau.fi/bridges/go/signal/index.html) bridge consists in a Synapse App Service and relies on postgresql (mysql also possible). Therefore, [Synapse for YunoHost](https://github.com/YunoHost-Apps/synapse_ynh) should be installed beforehand.
 
 
-**Paketatutako bertsioa:** 0.7.4~ynh1
+**Paketatutako bertsioa:** 0.7.4~ynh2
 ## Dokumentazioa eta baliabideak
 
 - Erabiltzaileen dokumentazio ofiziala: <https://docs.mau.fi/bridges/go/signal/index.html>

--- a/README_fr.md
+++ b/README_fr.md
@@ -25,7 +25,7 @@ La passerelle ["Mautrix-Signal"](https://docs.mau.fi/bridges/python/signal/index
 **Attention : sauvegardez et restaurez toujours les deux applications Yunohost matrix-synapse et mautrix_signal en même temps!**
 
 
-**Version incluse :** 0.7.4~ynh1
+**Version incluse :** 0.7.4~ynh2
 ## Documentations et ressources
 
 - Documentation officielle utilisateur : <https://docs.mau.fi/bridges/go/signal/index.html>

--- a/README_gl.md
+++ b/README_gl.md
@@ -24,7 +24,7 @@ Currently the Matrix user can NOT invite other Matrix user in a bridged Signal r
 The ["Mautrix-Signal"](https://docs.mau.fi/bridges/go/signal/index.html) bridge consists in a Synapse App Service and relies on postgresql (mysql also possible). Therefore, [Synapse for YunoHost](https://github.com/YunoHost-Apps/synapse_ynh) should be installed beforehand.
 
 
-**Versión proporcionada:** 0.7.4~ynh1
+**Versión proporcionada:** 0.7.4~ynh2
 ## Documentación e recursos
 
 - Documentación oficial para usuarias: <https://docs.mau.fi/bridges/go/signal/index.html>

--- a/README_id.md
+++ b/README_id.md
@@ -24,7 +24,7 @@ Currently the Matrix user can NOT invite other Matrix user in a bridged Signal r
 The ["Mautrix-Signal"](https://docs.mau.fi/bridges/go/signal/index.html) bridge consists in a Synapse App Service and relies on postgresql (mysql also possible). Therefore, [Synapse for YunoHost](https://github.com/YunoHost-Apps/synapse_ynh) should be installed beforehand.
 
 
-**Versi terkirim:** 0.7.4~ynh1
+**Versi terkirim:** 0.7.4~ynh2
 ## Dokumentasi dan sumber daya
 
 - Dokumentasi pengguna resmi: <https://docs.mau.fi/bridges/go/signal/index.html>

--- a/README_nl.md
+++ b/README_nl.md
@@ -24,7 +24,7 @@ Currently the Matrix user can NOT invite other Matrix user in a bridged Signal r
 The ["Mautrix-Signal"](https://docs.mau.fi/bridges/go/signal/index.html) bridge consists in a Synapse App Service and relies on postgresql (mysql also possible). Therefore, [Synapse for YunoHost](https://github.com/YunoHost-Apps/synapse_ynh) should be installed beforehand.
 
 
-**Geleverde versie:** 0.7.4~ynh1
+**Geleverde versie:** 0.7.4~ynh2
 ## Documentatie en bronnen
 
 - Officiele gebruikersdocumentatie: <https://docs.mau.fi/bridges/go/signal/index.html>

--- a/README_pl.md
+++ b/README_pl.md
@@ -24,7 +24,7 @@ Currently the Matrix user can NOT invite other Matrix user in a bridged Signal r
 The ["Mautrix-Signal"](https://docs.mau.fi/bridges/go/signal/index.html) bridge consists in a Synapse App Service and relies on postgresql (mysql also possible). Therefore, [Synapse for YunoHost](https://github.com/YunoHost-Apps/synapse_ynh) should be installed beforehand.
 
 
-**Dostarczona wersja:** 0.7.4~ynh1
+**Dostarczona wersja:** 0.7.4~ynh2
 ## Dokumentacja i zasoby
 
 - Oficjalna dokumentacja: <https://docs.mau.fi/bridges/go/signal/index.html>

--- a/README_ru.md
+++ b/README_ru.md
@@ -24,7 +24,7 @@ Currently the Matrix user can NOT invite other Matrix user in a bridged Signal r
 The ["Mautrix-Signal"](https://docs.mau.fi/bridges/go/signal/index.html) bridge consists in a Synapse App Service and relies on postgresql (mysql also possible). Therefore, [Synapse for YunoHost](https://github.com/YunoHost-Apps/synapse_ynh) should be installed beforehand.
 
 
-**Поставляемая версия:** 0.7.4~ynh1
+**Поставляемая версия:** 0.7.4~ynh2
 ## Документация и ресурсы
 
 - Официальная документация пользователя: <https://docs.mau.fi/bridges/go/signal/index.html>

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -24,7 +24,7 @@ Currently the Matrix user can NOT invite other Matrix user in a bridged Signal r
 The ["Mautrix-Signal"](https://docs.mau.fi/bridges/go/signal/index.html) bridge consists in a Synapse App Service and relies on postgresql (mysql also possible). Therefore, [Synapse for YunoHost](https://github.com/YunoHost-Apps/synapse_ynh) should be installed beforehand.
 
 
-**分发版本：** 0.7.4~ynh1
+**分发版本：** 0.7.4~ynh2
 ## 文档与资源
 
 - 官方用户文档： <https://docs.mau.fi/bridges/go/signal/index.html>

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Matrix Signal bridge"
 description.en = "Matrix / Synapse puppeting bridge for Signal"
 description.fr = "Passerelle Matrix / Synapse pour Signal"
 
-version = "0.7.4~ynh1"
+version = "0.7.4~ynh2"
 
 maintainers = ["MayeulC", "nathanael-h"]
 

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -38,34 +38,6 @@ wait_for_user_to_exist_in_synapse_db() {
 	return 0
 }
 
-set_bot_admin_status() {
-	# Set bot admin status in synapse DB
-	# This relies on several bash variables being set in the caller environment:
-	# server_name, botname, bot_synapse_adm, app
-
-	local timeout=120
-	local bot_synapse_db_user="@$botname:$server_name"
-	local synapse_db_name=$(get_synapse_db_name $synapse_instance)
-
-	ynh_print_info --message="Updating bot user admin status"
-	export -f wait_for_user_to_exist_in_synapse_db # Export function to subprocesses so that it may be called with timeout
-	# Wait until the user is created in synapse db
-	if ! timeout $timeout bash -c "wait_for_user_to_exist_in_synapse_db \"$bot_synapse_db_user\" \"$synapse_db_name\"" 2>&1; then
-		ynh_print_warn --message="Bot user $bot_synapse_db_user did not exist after $timeout seconds, skipping changing its admin status"
-	fi
-
-	# (Note that, by default, non-admins might not have your homeserver's permission to create communities.)
-	if [ "$bot_synapse_adm" = true ] || [ "$bot_synapse_adm" = "1" ]; then
-	    bot_synapse_adm=1
-	#    #yunohost app action run $synapse_instance set_admin_user -a username=$botname
-	else
-	    bot_synapse_adm=0
-	fi
-	ynh_psql_execute_as_root --database="$synapse_db_name" --sql="UPDATE users SET admin = $bot_synapse_adm WHERE name = '$bot_synapse_db_user';"
-
-	ynh_systemd_action --service_name="$app" --action="restart" --log_path="/var/log/$app/$app.log"
-}
-
 #=================================================
 # EXPERIMENTAL HELPERS
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -115,9 +115,6 @@ ynh_script_progression --message="Starting $app's systemd service..." --weight=2
 # Start a systemd service
 ynh_systemd_action --service_name="$app" --action="start" --log_path="/var/log/$app/$app.log"
 
-# Update bot admin status
-set_bot_admin_status
-
 #=================================================
 # END OF SCRIPT
 #=================================================

--- a/scripts/restore
+++ b/scripts/restore
@@ -71,9 +71,6 @@ ynh_script_progression --message="Starting $app's systemd service..." --weight=1
 # Start a systemd service
 ynh_systemd_action --service_name="$app" --action="start" --log_path="/var/log/$app/$app.log"
 
-# Update bot admin status
-set_bot_admin_status
-
 #=================================================
 # END OF SCRIPT
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -46,6 +46,15 @@ then
     source upgrade-pre-0.5.sh
 fi
 
+if ynh_compare_current_package_version --comparison lt --version 0.7.4~ynh2
+then # We may have leftover python files to clean, as this step was introduced in 0.7.4~ynh2
+	ynh_print_info --message="Cleaning up possible leftovers from python bridge version"
+	for target in bin include lib lib64 pyvenv.cfg share src .python_history example-config.yaml
+	do
+		rm -rf "${install_dir:?}/$target"
+	done
+fi
+
 #=================================================
 # DOWNLOAD, CHECK AND UNPACK SOURCE
 #=================================================


### PR DESCRIPTION
## Problem

- Leftover files
- Restore failed due to the admin setup step
- Admin user is not used anymore anyway

## Solution

- Cleanup leftover Python files on upgrade
- remove code path to set admin user

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
