### PR TITLE
Go back to sg_ as username tmplate

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -225,7 +225,7 @@ appservice:
 
     # Localpart template of MXIDs for remote users.
     # {{.}} is replaced with the internal ID of the user.
-    username_template: signal_{{.}}
+    username_template: sg_{{.}}
 
 # Config options that affect the Matrix connector of the bridge.
 matrix:


### PR DESCRIPTION
## Problem

- User name template change from sg_IDXYZ to signal_XYZ wich make a mess in chats

## Solution

- Go back to sg_IDXYZ the early as possible to not make que mess keep occuring on new messages

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

