### PR TITLE
Go back to sg_ as username tmplate (#139) and displayname (SG)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Currently the Matrix user can NOT invite other Matrix user in a bridged Signal r
 The ["Mautrix-Signal"](https://docs.mau.fi/bridges/go/signal/index.html) bridge consists in a Synapse App Service and relies on postgresql (mysql also possible). Therefore, [Synapse for YunoHost](https://github.com/YunoHost-Apps/synapse_ynh) should be installed beforehand.
 
 
-**Shipped version:** 0.7.5~ynh1
+**Shipped version:** 0.7.5~ynh2
 ## Documentation and resources
 
 - Official user documentation: <https://docs.mau.fi/bridges/go/signal/index.html>

--- a/README_es.md
+++ b/README_es.md
@@ -24,7 +24,7 @@ Currently the Matrix user can NOT invite other Matrix user in a bridged Signal r
 The ["Mautrix-Signal"](https://docs.mau.fi/bridges/go/signal/index.html) bridge consists in a Synapse App Service and relies on postgresql (mysql also possible). Therefore, [Synapse for YunoHost](https://github.com/YunoHost-Apps/synapse_ynh) should be installed beforehand.
 
 
-**Versión actual:** 0.7.5~ynh1
+**Versión actual:** 0.7.5~ynh2
 ## Documentaciones y recursos
 
 - Documentación usuario oficial: <https://docs.mau.fi/bridges/go/signal/index.html>

--- a/README_eu.md
+++ b/README_eu.md
@@ -24,7 +24,7 @@ Currently the Matrix user can NOT invite other Matrix user in a bridged Signal r
 The ["Mautrix-Signal"](https://docs.mau.fi/bridges/go/signal/index.html) bridge consists in a Synapse App Service and relies on postgresql (mysql also possible). Therefore, [Synapse for YunoHost](https://github.com/YunoHost-Apps/synapse_ynh) should be installed beforehand.
 
 
-**Paketatutako bertsioa:** 0.7.5~ynh1
+**Paketatutako bertsioa:** 0.7.5~ynh2
 ## Dokumentazioa eta baliabideak
 
 - Erabiltzaileen dokumentazio ofiziala: <https://docs.mau.fi/bridges/go/signal/index.html>

--- a/README_fr.md
+++ b/README_fr.md
@@ -25,7 +25,7 @@ La passerelle ["Mautrix-Signal"](https://docs.mau.fi/bridges/python/signal/index
 **Attention : sauvegardez et restaurez toujours les deux applications Yunohost matrix-synapse et mautrix_signal en même temps!**
 
 
-**Version incluse :** 0.7.5~ynh1
+**Version incluse :** 0.7.5~ynh2
 ## Documentations et ressources
 
 - Documentation officielle utilisateur : <https://docs.mau.fi/bridges/go/signal/index.html>

--- a/README_gl.md
+++ b/README_gl.md
@@ -24,7 +24,7 @@ Currently the Matrix user can NOT invite other Matrix user in a bridged Signal r
 The ["Mautrix-Signal"](https://docs.mau.fi/bridges/go/signal/index.html) bridge consists in a Synapse App Service and relies on postgresql (mysql also possible). Therefore, [Synapse for YunoHost](https://github.com/YunoHost-Apps/synapse_ynh) should be installed beforehand.
 
 
-**Versión proporcionada:** 0.7.5~ynh1
+**Versión proporcionada:** 0.7.5~ynh2
 ## Documentación e recursos
 
 - Documentación oficial para usuarias: <https://docs.mau.fi/bridges/go/signal/index.html>

--- a/README_id.md
+++ b/README_id.md
@@ -24,7 +24,7 @@ Currently the Matrix user can NOT invite other Matrix user in a bridged Signal r
 The ["Mautrix-Signal"](https://docs.mau.fi/bridges/go/signal/index.html) bridge consists in a Synapse App Service and relies on postgresql (mysql also possible). Therefore, [Synapse for YunoHost](https://github.com/YunoHost-Apps/synapse_ynh) should be installed beforehand.
 
 
-**Versi terkirim:** 0.7.5~ynh1
+**Versi terkirim:** 0.7.5~ynh2
 ## Dokumentasi dan sumber daya
 
 - Dokumentasi pengguna resmi: <https://docs.mau.fi/bridges/go/signal/index.html>

--- a/README_nl.md
+++ b/README_nl.md
@@ -24,7 +24,7 @@ Currently the Matrix user can NOT invite other Matrix user in a bridged Signal r
 The ["Mautrix-Signal"](https://docs.mau.fi/bridges/go/signal/index.html) bridge consists in a Synapse App Service and relies on postgresql (mysql also possible). Therefore, [Synapse for YunoHost](https://github.com/YunoHost-Apps/synapse_ynh) should be installed beforehand.
 
 
-**Geleverde versie:** 0.7.5~ynh1
+**Geleverde versie:** 0.7.5~ynh2
 ## Documentatie en bronnen
 
 - Officiele gebruikersdocumentatie: <https://docs.mau.fi/bridges/go/signal/index.html>

--- a/README_pl.md
+++ b/README_pl.md
@@ -24,7 +24,7 @@ Currently the Matrix user can NOT invite other Matrix user in a bridged Signal r
 The ["Mautrix-Signal"](https://docs.mau.fi/bridges/go/signal/index.html) bridge consists in a Synapse App Service and relies on postgresql (mysql also possible). Therefore, [Synapse for YunoHost](https://github.com/YunoHost-Apps/synapse_ynh) should be installed beforehand.
 
 
-**Dostarczona wersja:** 0.7.5~ynh1
+**Dostarczona wersja:** 0.7.5~ynh2
 ## Dokumentacja i zasoby
 
 - Oficjalna dokumentacja: <https://docs.mau.fi/bridges/go/signal/index.html>

--- a/README_ru.md
+++ b/README_ru.md
@@ -24,7 +24,7 @@ Currently the Matrix user can NOT invite other Matrix user in a bridged Signal r
 The ["Mautrix-Signal"](https://docs.mau.fi/bridges/go/signal/index.html) bridge consists in a Synapse App Service and relies on postgresql (mysql also possible). Therefore, [Synapse for YunoHost](https://github.com/YunoHost-Apps/synapse_ynh) should be installed beforehand.
 
 
-**Поставляемая версия:** 0.7.5~ynh1
+**Поставляемая версия:** 0.7.5~ynh2
 ## Документация и ресурсы
 
 - Официальная документация пользователя: <https://docs.mau.fi/bridges/go/signal/index.html>

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -24,7 +24,7 @@ Currently the Matrix user can NOT invite other Matrix user in a bridged Signal r
 The ["Mautrix-Signal"](https://docs.mau.fi/bridges/go/signal/index.html) bridge consists in a Synapse App Service and relies on postgresql (mysql also possible). Therefore, [Synapse for YunoHost](https://github.com/YunoHost-Apps/synapse_ynh) should be installed beforehand.
 
 
-**分发版本：** 0.7.5~ynh1
+**分发版本：** 0.7.5~ynh2
 ## 文档与资源
 
 - 官方用户文档： <https://docs.mau.fi/bridges/go/signal/index.html>

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -225,7 +225,7 @@ appservice:
 
     # Localpart template of MXIDs for remote users.
     # {{.}} is replaced with the internal ID of the user.
-    username_template: sg_{{.}}
+    username_template: __USERNAME_TEMPLATE__
 
 # Config options that affect the Matrix connector of the bridge.
 matrix:

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -6,7 +6,7 @@ network:
     # {{.PhoneNumber}} - The phone number of the user.
     # {{.UUID}} - The UUID of the Signal user.
     # {{.AboutEmoji}} - The emoji set by the user in their profile.
-    displayname_template: '{{or .ProfileName .PhoneNumber "Unknown user"}}'
+    displayname_template: '{{or .ProfileName .PhoneNumber "Unknown user"}} (SG)'
     # Should avatars from the user's contact list be used? This is not safe on multi-user instances.
     use_contact_avatars: false
     # Should the bridge request the user's contact list from the phone on startup?

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -225,6 +225,7 @@ appservice:
 
     # Localpart template of MXIDs for remote users.
     # {{.}} is replaced with the internal ID of the user.
+    # Please never adjust this value once you have started using the bridge as changing it is not supported
     username_template: __USERNAME_TEMPLATE__
 
 # Config options that affect the Matrix connector of the bridge.

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -225,7 +225,7 @@ appservice:
 
     # Localpart template of MXIDs for remote users.
     # {{.}} is replaced with the internal ID of the user.
-    username_template: signal_{{.}}
+    username_template: sg_{{.}}
 
 # Config options that affect the Matrix connector of the bridge.
 matrix:

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Matrix Signal bridge"
 description.en = "Matrix / Synapse puppeting bridge for Signal"
 description.fr = "Passerelle Matrix / Synapse pour Signal"
 
-version = "0.7.5~ynh1"
+version = "0.7.5~ynh2"
 
 maintainers = ["MayeulC", "nathanael-h"]
 

--- a/scripts/install
+++ b/scripts/install
@@ -50,7 +50,7 @@ fi
 server_name=$(ynh_app_setting_get --app "$synapse_instance" --key server_name)
 domain=$(ynh_app_setting_get --app "$synapse_instance" --key domain)
 mautrix_version=$(ynh_app_upstream_version)
-username_template="signal_{{.}}"
+username_template="sg_{{.}}"
 
 ynh_app_setting_set --app="$app" --key=synapse_instance --value="$synapse_instance"
 ynh_app_setting_set --app="$app" --key=enable_relaybot --value="$enable_relaybot"

--- a/scripts/install
+++ b/scripts/install
@@ -50,6 +50,7 @@ fi
 server_name=$(ynh_app_setting_get --app "$synapse_instance" --key server_name)
 domain=$(ynh_app_setting_get --app "$synapse_instance" --key domain)
 mautrix_version=$(ynh_app_upstream_version)
+username_template="sg_{{.}}"
 
 ynh_app_setting_set --app="$app" --key=synapse_instance --value="$synapse_instance"
 ynh_app_setting_set --app="$app" --key=enable_relaybot --value="$enable_relaybot"
@@ -60,6 +61,7 @@ ynh_app_setting_set --app="$app" --key=domain --value="$domain"
 ynh_app_setting_set --app="$app" --key=mautrix_version --value="$mautrix_version"
 
 ynh_app_setting_set --app="$app" --key=bot_synapse_adm --value="$bot_synapse_adm"
+ynh_app_setting_set --app="$app" --key=username_template --value="$username_template"
 
 #=================================================
 # DOWNLOAD, CHECK AND UNPACK SOURCE

--- a/scripts/install
+++ b/scripts/install
@@ -50,7 +50,7 @@ fi
 server_name=$(ynh_app_setting_get --app "$synapse_instance" --key server_name)
 domain=$(ynh_app_setting_get --app "$synapse_instance" --key domain)
 mautrix_version=$(ynh_app_upstream_version)
-username_template="sg_{{.}}"
+username_template="signal_{{.}}"
 
 ynh_app_setting_set --app="$app" --key=synapse_instance --value="$synapse_instance"
 ynh_app_setting_set --app="$app" --key=enable_relaybot --value="$enable_relaybot"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -54,11 +54,20 @@ fi
 # See https://github.com/YunoHost-Apps/mautrix_signal_ynh/pull/140
 if [ -z "$username_template" ]
 then
-    username_template="$(ynh_read_var_in_file --file="$install_dir/config.yaml" --key=username_template)"
-    if [ -z "$username_template" ]
-    then
-    username_template="sg_{{.}}"
+    # Check any if user was created with the old "sg_" prefix
+    # First, check if the mx_registrations table exists: if not, no users have been created
+    ret=$(sudo -u postgres psql --dbname="$db_name" -q -t -c "SELECT EXISTS(SELECT 1 FROM information_schema.tables WHERE table_name = 'mx_registrations');")
+    if [ "$ret" = t ]
+    then # The table exists, check for users
+        ret=$(sudo -u postgres psql --dbname="$db_name" -q -t -c "SELECT EXISTS(SELECT 1 FROM mx_registrations WHERE user_id LIKE '@sg_%');")
     fi
+    if [ "$ret" = " t" ]
+    then # At least one @sg_* user exists in the database
+        username_template="sg_{{.}}"
+    else # The table does not exist, or no users named "@sg_*"
+        username_template="signal_{{.}}"
+    fi # Otherwise, we rely on the default from above
+    ynh_print_info "Detected username template $username_template from the database, saving it in settings"
     ynh_app_setting_set --app="$app" --key=username_template --value="$username_template"
 fi
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -13,6 +13,7 @@ mautrix_version=$(ynh_app_upstream_version)
 synapse_db_name="$(get_synapse_db_name $synapse_instance)"
 server_name=$(ynh_app_setting_get --app $synapse_instance --key server_name)
 domain=$(ynh_app_setting_get --app $synapse_instance --key domain)
+username_template=$(ynh_app_setting_get --app $app --key username_template)
 
 #=================================================
 # CHECK VERSION
@@ -44,6 +45,21 @@ ynh_script_progression --message="Ensuring downward compatibility..." --weight=1
 if ynh_compare_current_package_version --comparison lt --version 0.5.0~ynh1
 then
     source upgrade-pre-0.5.sh
+fi
+
+# Between november 2024 to february 2025 the username_template was set to signal_{{.}}
+# This change broke previous installed instance which was declared with sg_{{.}}
+# Upstream doesn't allow to change this var, so we need to support both now.
+# That's why username_template config key was templatized
+# See https://github.com/YunoHost-Apps/mautrix_signal_ynh/pull/140
+if [ -z "$username_template" ]
+then
+    username_template="$(ynh_read_var_in_file --file="$install_dir/config.yaml" --key=username_template)"
+    if [ -z "$username_template" ]
+    then
+    username_template="sg_{{.}}"
+    fi
+    ynh_app_setting_set --app="$app" --key=username_template --value="$username_template"
 fi
 
 #=================================================


### PR DESCRIPTION
## Problem

- changing the username template is not authorized upstream
- everyone who installed this bridge before the change from sg_ to signal_ takes the risk to get their bridge messed up at each upgrade

## Solution

- get back to original sg_

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Related tickets
- fixes #135 

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
