### PR TITLE
More complete fix for username template

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -50,7 +50,7 @@ fi
 server_name=$(ynh_app_setting_get --app "$synapse_instance" --key server_name)
 domain=$(ynh_app_setting_get --app "$synapse_instance" --key domain)
 mautrix_version=$(ynh_app_upstream_version)
-username_template="sg_{{.}}"
+username_template="signal_{{.}}"
 
 ynh_app_setting_set --app="$app" --key=synapse_instance --value="$synapse_instance"
 ynh_app_setting_set --app="$app" --key=enable_relaybot --value="$enable_relaybot"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -54,11 +54,20 @@ fi
 # See https://github.com/YunoHost-Apps/mautrix_signal_ynh/pull/140
 if [ -z "$username_template" ]
 then
-    username_template="$(ynh_read_var_in_file --file="$install_dir/config.yaml" --key=username_template)"
-    if [ -z "$username_template" ]
-    then
-    username_template="sg_{{.}}"
+    # Check any if user was created with the old "sg_" prefix
+    # First, check if the mx_registrations table exists: if not, no users have been created
+    ret=$(sudo -u postgres psql --dbname="$db_name" -q -t -c "SELECT EXISTS(SELECT 1 FROM information_schema.tables WHERE table_name = 'mx_registrations');")
+    if [ "$ret" = t ]
+    then # The table exists, check for users
+        ret=$(sudo -u postgres psql --dbname="$db_name" -q -t -c "SELECT EXISTS(SELECT 1 FROM mx_registrations WHERE user_id LIKE '@sg_%');")
     fi
+    if [ "$ret" = " t" ]
+    then # At least one @sg_* user exists in the database
+        username_template="sg_{{.}}"
+    else # The table does not exist, or no users named "@sg_*"
+        username_template="signal_{{.}}"
+    fi # Otherwise, we rely on the default from above
+    ynh_print_info "Detected username template $username_template from the database, saving it in settings"
     ynh_app_setting_set --app="$app" --key=username_template --value="$username_template"
 fi
 

--- a/tests.toml
+++ b/tests.toml
@@ -13,3 +13,4 @@ test_format = 1.0
     args.botusers = "synapsedomain.tld"
 
     test_upgrade_from.53ee4060497125585a0da304a4128985028d6aee.name = "Upgrade from 0.6.1~ynh1 (first Go version)"
+    test_upgrade_from.939bdf59fc32e5fc7b8d67b35d07c0175823951d.name = "Upgrade from 0.7.3~ynh1 (last version with sg_ prefix)"


### PR DESCRIPTION
## Problem

- The current testing branch will break installs that were done with a `signal_` prefix

## Solution

- Add  a smarter check that uses the database in order to detect the prefix to keep when upgrading.

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
