### PR TITLE
Add a chmod for the log filder in the install script

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -108,6 +108,9 @@ yunohost service add "$app" --description="$app daemon for bridging Signal and M
 
 # Use logrotate to manage application logfile(s)
 ynh_use_logrotate --logfile "/var/log/$app/$app.log" --nonappend --specific_user "$app/$app"
+chmod -R 600 "/var/log/$app"
+chmod 700 "/var/log/$app"
+chown -R $app:$app /var/log/$app
 
 #=================================================
 # START SYSTEMD SERVICE


### PR DESCRIPTION
## Problem

- After a clean install, the Signal Bridge Bot room won't respond.
- The mautrix_signal service does not start
- In the services log, we can see the following error message `mautrix-signal[6581]: Failed to initialize logger: failed to parse config for writer #2: can't open new logfile: open /var/log/mautrix_signal/mautrix_signal.log: permission denied`

- The problem has been mentioned (and solved on his machine) by user "Boudewijn" in the [Matrix Bridges Yunohost](https://matrix.to/#/#matrix_yunohost:sans-nuage.fr ) room on 2025-03-12

## Solution

- Copy-paste the lines 134-136 from the [mautrix_whatsapp_ynh install script](https://github.com/YunoHost-Apps/mautrix_whatsapp_ynh/blob/master/scripts/install), which are the ones related to /var/log/{app}/{app}.log permissions.


## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)
   - [x] running the following command as root on my machine after the installation solved the issue:
```bash
app=mautrix_signal
chmod -R 600 "/var/log/$app"
chmod 700 "/var/log/$app"
chown -R $app:$app /var/log/$app
```

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
